### PR TITLE
feat: Runtime support for 1.11.240.

### DIFF
--- a/include/F4SE/Version.h
+++ b/include/F4SE/Version.h
@@ -59,6 +59,7 @@ namespace F4SE
 	inline constexpr REL::Version RUNTIME_1_11_169{ 1, 11, 169, 0 };
 	inline constexpr REL::Version RUNTIME_1_11_191{ 1, 11, 191, 0 };
 	inline constexpr REL::Version RUNTIME_1_11_221{ 1, 11, 221, 0 };
+	inline constexpr REL::Version RUNTIME_1_11_240{ 1, 11, 240, 0 };
 
-	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_11_221;
+	inline constexpr auto RUNTIME_LATEST = RUNTIME_1_11_240;
 }

--- a/include/RE/P/PipboyPrimitiveValue.h
+++ b/include/RE/P/PipboyPrimitiveValue.h
@@ -17,7 +17,9 @@ namespace RE
 
 		PipboyPrimitiveValue(std::uint32_t a_value, PipboyValue* a_parent) :
 			PipboyValue(a_parent), m_value(a_value)
-		{}
+		{
+			REX::EMPLACE_VTABLE(this);
+		}
 
 		// override
 		virtual void                    CleanDirtyToGame() override {}                                                                                              // 00
@@ -52,7 +54,9 @@ namespace RE
 
 		PipboyPrimitiveValue(bool a_value, PipboyValue* a_parent) :
 			PipboyValue(a_parent), m_value(a_value)
-		{}
+		{
+			REX::EMPLACE_VTABLE(this);
+		}
 
 		// override
 		virtual void                    CleanDirtyToGame() override {}                                                                                              // 00

--- a/include/RE/P/PipboyValue.h
+++ b/include/RE/P/PipboyValue.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "RE/M/MemoryManager.h"
+
 namespace Json
 {
 	class Value;
@@ -47,6 +49,8 @@ namespace RE
 			static REL::Relocation<func_t> func{ ID::PipboyValue::ctor };
 			func(this, a_parent);
 		}
+
+		F4_HEAP_REDEFINE_NEW(PipboyValue)
 
 		// members
 		std::uint32_t m_id;                  // 0x08


### PR DESCRIPTION
fix: Missing EMPLACE_VTABLEs in PipboyValue & PipboyPrimiteValue